### PR TITLE
Set specific Google Cloud project and location in environment variables

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -20,8 +20,8 @@ import google.auth
 from google.adk.agents import Agent
 
 _, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "qwiklabs-gcp-03-ec92c6095411")
+os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "europe-west2")
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 


### PR DESCRIPTION
Update environment variables to use a specific Google Cloud project and location instead of default values.